### PR TITLE
totalOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Enable this if you'd prefer to see the durations reported in a friendly hours/mi
 Task 'jshint:all' took 3 seconds 
 ```
 
+### totalOnly
+
+Enable this if you'd prefer to only see the time all tasks took to complete.
+
+This is useful for having many small, insignificant tasks that would generate considerable output even with deferLogs.
+
+```
+All tasks took 502ms
+```
+
 ## Notes
 
 - The last task duration is output after the "Done, without errors". This is due to the way the hooking for the task name change works.

--- a/grunt-timer.js
+++ b/grunt-timer.js
@@ -6,6 +6,7 @@ exports = module.exports = (function () {
     var timer = {}, grunt, hooker, last, task,
         total = 0,
         deferLogs = false,
+        totalOnly = false,
         friendlyTime = false,
         deferredMessages = [];
 
@@ -25,18 +26,20 @@ exports = module.exports = (function () {
         var hrs = (s - mins) / 60;
 
         return (hrs ? hrs + (hrs > 1 ? " hours " : " hour ") : "") +
-                (mins ? mins + (mins > 1 ? " minutes " : " minute ") : "") +
-                secs + (secs > 1 ? " seconds " : " second ");
+            (mins ? mins + (mins > 1 ? " minutes " : " minute ") : "") +
+            secs + (secs > 1 ? " seconds " : " second ");
     };
 
     var logCurrent = function () {
         var dur = new duration(last).milliseconds;
         if (dur > 2) {
             var logMsg = "Task '" + task + "' took " + getDisplayTime(dur);
-            if (deferLogs) {
-                deferredMessages.push(logMsg);
-            } else {
-                grunt.log.writeln(colour.purple(logMsg));
+            if(!totalOnly){
+                if (deferLogs) {
+                    deferredMessages.push(logMsg);
+                } else {
+                    grunt.log.writeln(colour.purple(logMsg));
+                }
             }
             addToTotal(dur);
         }
@@ -58,6 +61,7 @@ exports = module.exports = (function () {
 
         deferLogs = !!options.deferLogs;
         friendlyTime = !!options.friendlyTime;
+        totalOnly    = !!options.totalOnly;
 
         hooker.hook(grunt.log, "header", function () {
             if (!task) {


### PR DESCRIPTION
Our team is really only worried about the total time it takes for all tasks to complete, (one multitask is more 100 tasks for example...).  The timer is great, but being able to cut out lots of output we never use would be even greater.
