### PR TITLE
Use hooker module instead of grunt.util.hooker

### DIFF
--- a/grunt-timer.js
+++ b/grunt-timer.js
@@ -1,9 +1,10 @@
 var duration = require("duration"),
-    colour = require("bash-color");
+    colour = require("bash-color"),
+    hooker = require("hooker");
 
 exports = module.exports = (function () {
     "use strict";
-    var timer = {}, grunt, hooker, last, task,
+    var timer = {}, grunt, last, task,
         total = 0,
         deferLogs = false,
         totalOnly = false,
@@ -55,7 +56,6 @@ exports = module.exports = (function () {
 
     timer.init = function (_grunt, options) {
         grunt = _grunt;
-        hooker = grunt.util.hooker;
         total = 0;
         options = options || {};
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "duration": "~0.1.x",
-    "bash-color": "0.0.x"
+    "bash-color": "0.0.x",
+    "hooker": "~0.2.3"
   }
 }


### PR DESCRIPTION
Because `grunt.util.hooker` is [deprecated](http://gruntjs.com/api/grunt.util#grunt.util.hooker).
