### PR TITLE
Adds a deferLogsAndWriteInLine config option

### DIFF
--- a/grunt-timer.js
+++ b/grunt-timer.js
@@ -126,7 +126,7 @@ exports = module.exports = (function () {
 
         process.on("exit", function () {
             logCurrent();
-            if (deferLogs) {
+            if (deferLogs || deferLogsAndWriteInLine) {
                 logDeferred();
             }
             logTotal();

--- a/grunt-timer.js
+++ b/grunt-timer.js
@@ -8,6 +8,7 @@ exports = module.exports = (function () {
     var timer = {}, grunt, last, task,
         total = 0,
         deferLogs = false,
+        deferLogsAndWriteInLine = false,
         totalOnly = false,
         friendlyTime = false,
         ignoreAlias = [],
@@ -31,7 +32,11 @@ exports = module.exports = (function () {
         if (dur > 2) {
             var logMsg = "Task '" + task + "' took " + getDisplayTime(dur);
             if (!totalOnly) {
-                if (deferLogs) {
+                if (deferLogsAndWriteInLine) {
+                    deferredMessages.push(logMsg);
+                    writeLn(logMsg);
+                }
+                else if (deferLogs) {
                     deferredMessages.push(logMsg);
                 } else {
                     writeLn(logMsg);
@@ -92,6 +97,7 @@ exports = module.exports = (function () {
         options = _options || {};
 
         deferLogs = !! options.deferLogs;
+        deferLogsAndWriteInLine = !! options.deferLogsAndWriteInLine;
         friendlyTime = !! options.friendlyTime;
         totalOnly = !! options.totalOnly;
         ignoreAlias = options.ignoreAlias || [];


### PR DESCRIPTION
Right now deferLogs and inline stats are mutually exclusive. This PR lets us do both in backwards compatible way. This is important for us, since the summary at the end helps us analyze all task easily, but sometimes a build might timeout, which means we will miss the summary. 
